### PR TITLE
Feature/31 lobby expiration

### DIFF
--- a/server/__tests__/lobbies.test.js
+++ b/server/__tests__/lobbies.test.js
@@ -1,4 +1,4 @@
-import { addLobby, LOBBY_LIFESPAN } from "../lobbies";
+import { addLobby, getAllLobbies, LOBBY_LIFESPAN } from "../lobbies";
 
 // Mock persistence so DB doesn't change during tests
 jest.mock("../persistence", () => ({
@@ -20,9 +20,8 @@ describe("Lobby actions", () => {
       };
       addLobby(lobbyData);
 
-      const spliceFn = jest.spyOn(Array.prototype, "splice");
       jest.advanceTimersByTime(LOBBY_LIFESPAN);
-      expect(spliceFn).toHaveBeenCalled();
+      expect(getAllLobbies()).toHaveLength(0);
     });
 
     it("shouldn't be deleted after 15min if players list changes in the middle", () => {
@@ -32,17 +31,16 @@ describe("Lobby actions", () => {
         code: "7025",
       };
       const lobby = addLobby(lobbyData);
-      const spliceFn = jest.spyOn(Array.prototype, "splice");
 
       jest.advanceTimersByTime(LOBBY_LIFESPAN / 2);
-      lobby.addPlayer("2VDBVQ-6MD2F1rWJXdgyBodBp0YjAY89"); // change player list in the middle
+      lobby.addPlayer("2VDBVQ-6MD2F1rWJXdgyBodBp0YjAY89"); // change player list in the mean time
       jest.advanceTimersByTime(LOBBY_LIFESPAN / 2);
 
-      expect(spliceFn).not.toHaveBeenCalled(); // did not call 15min after creation event
+      expect(getAllLobbies()).toContain(lobby); // did not delete 15min after creation event
 
       jest.advanceTimersByTime(LOBBY_LIFESPAN / 2);
 
-      expect(spliceFn).toHaveBeenCalled(); // did call 15min after player addition
+      expect(getAllLobbies()).toHaveLength(0); // did delete 15min after player addition
     });
 
     afterEach(() => {

--- a/server/__tests__/lobbies.test.js
+++ b/server/__tests__/lobbies.test.js
@@ -1,0 +1,53 @@
+import { addLobby, LOBBY_LIFESPAN } from "../lobbies";
+
+// Mock persistence so DB doesn't change during tests
+jest.mock("../persistence", () => ({
+  save: jest.fn(),
+  load: jest.fn(() => []),
+}));
+
+describe("Lobby actions", () => {
+  describe("Lobby expiration", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    it("should be deleted after 15min of inactivity", () => {
+      const lobbyData = {
+        id: "rbbfJ5t3Zzpcj0TZxmYsM",
+        players: ["2VDBVQ-6MD2F1rWJXdgyBodBp0YjAY88"],
+        code: "7025",
+      };
+      addLobby(lobbyData);
+
+      const spliceFn = jest.spyOn(Array.prototype, "splice");
+      jest.advanceTimersByTime(LOBBY_LIFESPAN);
+      expect(spliceFn).toHaveBeenCalled();
+    });
+
+    it("shouldn't be deleted after 15min if players list changes in the middle", () => {
+      const lobbyData = {
+        id: "rcxxx5t3Zzpcj0TZxmYsM",
+        players: ["2VDBVQ-6MD2F1rWJXdgyBodBp0YjAY88"],
+        code: "7025",
+      };
+      const lobby = addLobby(lobbyData);
+      const spliceFn = jest.spyOn(Array.prototype, "splice");
+
+      jest.advanceTimersByTime(LOBBY_LIFESPAN / 2);
+      lobby.addPlayer("2VDBVQ-6MD2F1rWJXdgyBodBp0YjAY89"); // change player list in the middle
+      jest.advanceTimersByTime(LOBBY_LIFESPAN / 2);
+
+      expect(spliceFn).not.toHaveBeenCalled(); // did not call 15min after creation event
+
+      jest.advanceTimersByTime(LOBBY_LIFESPAN / 2);
+
+      expect(spliceFn).toHaveBeenCalled(); // did call 15min after player addition
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.clearAllMocks();
+    });
+  });
+});

--- a/server/lobbies.js
+++ b/server/lobbies.js
@@ -2,11 +2,14 @@ import { nanoid } from "nanoid";
 import { save, load } from "./persistence";
 import { randomInt } from "./utils/random";
 
+const LOBBY_TIMESPAN = 10000 // 30s
 export class Lobby {
   constructor({ id, players, code }) {
     this.id = id || nanoid();
     this.players = players || [];
-    this.code = code || String(randomInt(1000, 9999));
+	this.code = code || String(randomInt(1000, 9999));
+	this.expirationId = 0
+	this.hit()
   }
 
   addPlayer(player) {
@@ -15,6 +18,17 @@ export class Lobby {
     // TODO temp disable
     // eslint-disable-next-line no-use-before-define
     save(lobbies);
+    this.hit()
+  }
+
+  // every time this function is called, a new timeout is generated
+  hit() {
+    this.expirationId++
+    setTimeout(() => this.expire(this.expirationId), LOBBY_TIMESPAN)
+  }
+
+  expire(expireId) {
+    if (expireId == this.expirationId) deleteLobby(this.id)
   }
 }
 
@@ -34,7 +48,7 @@ export const getLobbyByCode = (code) => {
 
 export const addLobby = (lobbyData) => {
   const lobby = new Lobby(lobbyData);
-  lobbies.push(lobby);
+  lobbies.push(lobby);	
 
   save(lobbies);
 
@@ -42,9 +56,10 @@ export const addLobby = (lobbyData) => {
 };
 
 export const deleteLobby = (id) => {
+  console.log("Deleting Lobby", id)
   const lobby = lobbies.find((item) => item.id === id);
   if (lobby) {
-    lobbies.remove(lobby);
+    lobbies.splice(lobby);
     save(lobbies);
     return true;
   }

--- a/server/lobbies.js
+++ b/server/lobbies.js
@@ -8,7 +8,6 @@ export class Lobby {
     this.id = id || nanoid();
     this.players = players || [];
     this.code = code || String(randomInt(1000, 9999));
-    this.expirationId = 0;
     this.hit();
   }
 
@@ -23,15 +22,10 @@ export class Lobby {
 
   // every time this function is called, a new timeout is generated
   hit() {
-    this.expirationId += 1;
-    const id = this.expirationId;
-    setTimeout(() => this.expire(id), LOBBY_LIFESPAN);
-  }
-
-  expire(expireId) {
-    if (expireId === this.expirationId) {
-      deleteLobby(this.id);
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
     }
+    this.timeoutId = setTimeout(() => deleteLobby(this.id), LOBBY_LIFESPAN);
   }
 }
 

--- a/server/lobbies.js
+++ b/server/lobbies.js
@@ -2,14 +2,14 @@ import { nanoid } from "nanoid";
 import { save, load } from "./persistence";
 import { randomInt } from "./utils/random";
 
-export const LOBBY_LIFESPAN = 15 * 60000 // 15min
+export const LOBBY_LIFESPAN = 15 * 60000; // 15min
 export class Lobby {
   constructor({ id, players, code }) {
     this.id = id || nanoid();
     this.players = players || [];
-	this.code = code || String(randomInt(1000, 9999));
-	this.expirationId = 0
-	this.hit()
+    this.code = code || String(randomInt(1000, 9999));
+    this.expirationId = 0;
+    this.hit();
   }
 
   addPlayer(player) {
@@ -18,18 +18,20 @@ export class Lobby {
     // TODO temp disable
     // eslint-disable-next-line no-use-before-define
     save(lobbies);
-    this.hit()
+    this.hit();
   }
 
   // every time this function is called, a new timeout is generated
   hit() {
-	this.expirationId++
-	const id = this.expirationId
-    setTimeout(() => this.expire(id), LOBBY_LIFESPAN)
+    this.expirationId += 1;
+    const id = this.expirationId;
+    setTimeout(() => this.expire(id), LOBBY_LIFESPAN);
   }
 
   expire(expireId) {
-    if (expireId == this.expirationId) deleteLobby(this.id)
+    if (expireId === this.expirationId) {
+      deleteLobby(this.id);
+    }
   }
 }
 
@@ -49,7 +51,7 @@ export const getLobbyByCode = (code) => {
 
 export const addLobby = (lobbyData) => {
   const lobby = new Lobby(lobbyData);
-  lobbies.push(lobby);	
+  lobbies.push(lobby);
 
   save(lobbies);
 
@@ -57,7 +59,7 @@ export const addLobby = (lobbyData) => {
 };
 
 export const deleteLobby = (id) => {
-  console.log("Deleting Lobby", id)
+  console.log("Deleting Lobby", id);
   const lobby = lobbies.find((item) => item.id === id);
   if (lobby) {
     lobbies.splice(lobby);

--- a/server/lobbies.js
+++ b/server/lobbies.js
@@ -2,7 +2,7 @@ import { nanoid } from "nanoid";
 import { save, load } from "./persistence";
 import { randomInt } from "./utils/random";
 
-const LOBBY_TIMESPAN = 10000 // 30s
+export const LOBBY_LIFESPAN = 15 * 60000 // 15min
 export class Lobby {
   constructor({ id, players, code }) {
     this.id = id || nanoid();
@@ -23,8 +23,9 @@ export class Lobby {
 
   // every time this function is called, a new timeout is generated
   hit() {
-    this.expirationId++
-    setTimeout(() => this.expire(this.expirationId), LOBBY_TIMESPAN)
+	this.expirationId++
+	const id = this.expirationId
+    setTimeout(() => this.expire(id), LOBBY_LIFESPAN)
   }
 
   expire(expireId) {


### PR DESCRIPTION
Do #31.

First of all, I think there was a bug in `deleteLobby()` function in `lobbies.js`. `lobbies.remove()` is undefined. I changed it to `lobbies.splice()`.

## Description
As explained in the issue, a lobby must be removed after it is inactive for at least 15 minutes, where "inactive" means that the game hasn't started and the player list hasn't changed. To do so, a `hit()` method was created for a lobby, where a new timeout is sent with a new id, and an `expire()` method invokes the deletion of the lobby. 

## Tests

Two tests were created. 
- The first one asserts that 15min after the creation of the lobby, `deleteLobby` is invoked.
- The second one asserts that it is not deleted after 15min if player List changes in the meantime.

## Notes
- Every other future method of Lobby class that changes it's player list must call `this.hit()`. For example, `deletePlayer`, which is not yet implemented, must do that.
- Besides, when game starts, timeouts must stop being generated for the lobby. I didn't implement it yet because I didn't know how to do it right now

Feel free to suggest anything you would like me to change! :D